### PR TITLE
Prettier error messages

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,6 @@ Promise.map(files, function (file) {
   leprechaun.success('YAML Lint successful.');
 }).catch(function (error) {
   leprechaun.error('YAML Lint failed.');
-  console.error(error);
+  console.error(error.message);
   process.exit(1);
 });


### PR DESCRIPTION
Before: 

```
❯ yamllint .travis.yml
✖ YAML Lint failed.
{ Error
    at generateError (/Users/tema/n/lib/node_modules/yaml-lint/node_modules/js-yaml/lib/js-yaml/loader.js:162:10)
    at throwError (/Users/tema/n/lib/node_modules/yaml-lint/node_modules/js-yaml/lib/js-yaml/loader.js:168:9)
...
     position: 705,
     line: 30,
     column: 2 },
  message: 'bad indentation of a mapping entry at line 31, column 3:\n      - \'if [ "$WEBPACK_VERSION" ]; th ... \n      ^' }
```

After:

```
❯ yamllint .travis.yml
✖ YAML Lint failed.
bad indentation of a mapping entry at line 31, column 3:
      - 'if [ "$WEBPACK_VERSION" ]; th ...
      ^
```