### PR TITLE
Multiple files inside one yaml file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,7 @@ var files = [];
 });
 
 if (config.multi) {
-  files = files.concat(glob.sync(config.multi))
+  files = files.concat(glob.sync(config.multi));
   options.allowMulti = true;
 } else {
   options.allowMulti = false;

--- a/cli.js
+++ b/cli.js
@@ -32,6 +32,13 @@ var files = [];
   files = files.concat(glob.sync(file));
 });
 
+if (config.multi) {
+  files = files.concat(glob.sync(config.multi))
+  options.allowMulti = true;
+} else {
+  options.allowMulti = false;
+}
+
 if (files.length === 0) {
 
   leprechaun.error('YAML Lint failed.');
@@ -45,8 +52,8 @@ if (files.length === 0) {
       err.file = file;
       throw err;
     });
-  }).then(function () {
-    leprechaun.success('YAML Lint successful.');
+  }).then(function (file) {
+    leprechaun.success('YAML Lint successful for '+file);
   }).catch(function (error) {
     leprechaun.error('YAML Lint failed for ' + error.file);
     console.error(error.message);

--- a/test/testMulti.yaml
+++ b/test/testMulti.yaml
@@ -1,0 +1,5 @@
+shouldWork: yes
+
+---
+
+thisIsOnlyWhenMulti: yes

--- a/test/tests.js
+++ b/test/tests.js
@@ -32,3 +32,19 @@ tap.test('Missing file', function (childTest) {
     childTest.end();
   });
 });
+
+tap.test('Disallowed multi stream files', function (childTest) {
+  yamlLint.lintFile(path.resolve(__dirname, 'testMulti.yaml'), {allowMulti: false}).then(function () {
+    throw new Error();
+  }).catch(function (e) {
+    childTest.end();
+  });
+});
+
+tap.test('Allowed multi stream files', function (childTest) {
+  yamlLint.lintFile(path.resolve(__dirname, 'testMulti.yaml'), {allowMulti: true}).then(function () {
+    childTest.end();
+  }).catch(function (e) {
+    throw e;
+  });
+});

--- a/yaml-lint.js
+++ b/yaml-lint.js
@@ -6,6 +6,8 @@ var yaml = require('js-yaml');
 
 function lint(content, opts) {
 
+  opts = opts || {};
+
   var options = merge({
     schema: 'DEFAULT_SAFE_SCHEMA'
   }, opts);
@@ -13,12 +15,12 @@ function lint(content, opts) {
   return new Promise(function (resolve, reject) {
     try {
       if (!opts.allowMulti) {
-        var doc = yaml.safeLoad(content, {
+        yaml.safeLoad(content, {
           schema: yaml[options.schema]
         });
         resolve();
       } else {
-        var doc = yaml.safeLoadAll(content, function(doc) {}, {
+        yaml.safeLoadAll(content, function(doc) {}, {
           schema: yaml[options.schema]
         });
         resolve();

--- a/yaml-lint.js
+++ b/yaml-lint.js
@@ -3,6 +3,7 @@ var merge = require('lodash.merge');
 var Promise = require('bluebird');
 var yaml = require('js-yaml');
 
+
 function lint(content, opts) {
 
   var options = merge({
@@ -11,10 +12,17 @@ function lint(content, opts) {
 
   return new Promise(function (resolve, reject) {
     try {
-      var doc = yaml.safeLoadAll(content, function(doc) {}, {
-        schema: yaml[options.schema]
-      });
-      resolve();
+      if (!opts.allowMulti) {
+        var doc = yaml.safeLoad(content, {
+          schema: yaml[options.schema]
+        });
+        resolve();
+      } else {
+        var doc = yaml.safeLoadAll(content, function(doc) {}, {
+          schema: yaml[options.schema]
+        });
+        resolve();
+      }
     } catch (e) {
       reject(e);
     }
@@ -29,7 +37,7 @@ function lintFile(file, opts) {
         reject(err);
       } else {
         lint(content, opts).then(function (result) {
-          resolve(result);
+          resolve(file);
         }).catch(function (e) {
           reject(e);
         });

--- a/yaml-lint.js
+++ b/yaml-lint.js
@@ -11,7 +11,7 @@ function lint(content, opts) {
 
   return new Promise(function (resolve, reject) {
     try {
-      var doc = yaml.safeLoad(content, {
+      var doc = yaml.safeLoadAll(content, function(doc) {}, {
         schema: yaml[options.schema]
       });
       resolve();


### PR DESCRIPTION
When having multiple file streams inside yaml files, the curren tool fails to validate them.

With this PR, you can add "--multi" to cli.js to make the parsing allow multiple files or not. It also improves the output a little so that you can see which files are approved. It becomes more useful in for instance Travis och Jenkins or other build tools.