### PR TITLE
docs: fix config file name, note arrays for ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yamllint test.yaml
 
 YAML Lint is configured using the following options via a configuration file, environment variables, and/or command-line arguments.
 
-First of all, YAML Lint looks for a JSON file called `yaml-lint.json` within the current working directory.
+First of all, YAML Lint looks for a JSON file called `.yaml-lint.json` within the current working directory.
 
 ```json
 {
@@ -72,7 +72,7 @@ yamllint --schema=CORE_SCHEMA --ignore=dir/*.yaml
 - `CORE_SCHEMA` Same as `JSON_SCHEMA` ([http://www.yaml.org/spec/1.2/spec.html#id2804923](http://www.yaml.org/spec/1.2/spec.html#id2804923))
 - `DEFAULT_SAFE_SCHEMA` All supported YAML types, without unsafe ones (`!!js/undefined`, `!!js/regexp`, and `!!js/function`) ([http://yaml.org/type/](http://yaml.org/type/))
 
-### `ignore` (string)
+### `ignore` (string or array of strings)
 
 > Specifies one or multiple glob patterns to ignore
 


### PR DESCRIPTION
The README disagreed with the code on the configuration file name in that the former had `yaml-lint.json` whereas the latter looked for `.yaml-lint.json`. I suppose there aren't unit tests for the configuration features yet.

Also, I updated the `ignore` section to include that it supports arrays of strings, like `glob` underlying does.