### PR TITLE
fix: Export js-yaml types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
+        "@types/js-yaml": "^4.0.5",
         "consola": "^2.15.3",
         "globby": "^11.1.0",
         "js-yaml": "^4.1.0",
@@ -20,7 +21,6 @@
       "devDependencies": {
         "@jest/globals": "^27.5.1",
         "@types/jest": "^27.4.1",
-        "@types/js-yaml": "^4.0.5",
         "@types/nconf": "^0.10.2",
         "@types/node": "^16.11.27",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
@@ -1206,8 +1206,7 @@
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
-      "dev": true
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -7351,8 +7350,7 @@
     "@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
-      "dev": true
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA=="
     },
     "@types/json-schema": {
       "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cli"
   ],
   "dependencies": {
+    "@types/js-yaml": "^4.0.5",
     "consola": "^2.15.3",
     "globby": "^11.1.0",
     "js-yaml": "^4.1.0",
@@ -32,7 +33,6 @@
   "devDependencies": {
     "@jest/globals": "^27.5.1",
     "@types/jest": "^27.4.1",
-    "@types/js-yaml": "^4.0.5",
     "@types/nconf": "^0.10.2",
     "@types/node": "^16.11.27",
     "@typescript-eslint/eslint-plugin": "^5.20.0",


### PR DESCRIPTION
Fix https://github.com/rasshofer/yaml-lint/issues/35